### PR TITLE
Adding tools to print a stacktrace

### DIFF
--- a/source/grimoire/assembly/debug_info.d
+++ b/source/grimoire/assembly/debug_info.d
@@ -2,19 +2,33 @@ module grimoire.assembly.debug_info;
 
 import std.format;
 
+/**
+A class that contains debug information, should always be overridden
+*/
 public class GrDebugInfo {
-    string to_string() {
-        return "EMPTY";
-    }
+    /**
+    Stringify the debug information
+    */
+    abstract string to_string();
 }
 
 public class GrFunctionInfo : GrDebugInfo {
     public {
+        /**
+        Location of the function in the bytecode
+        */
         uint bytecodePosition;
+        /**
+        Number of opcodes in the function
+        */
+        uint length;
+        /**
+        Name of the function
+        */
         string functionName;
     }
 
     override string to_string() {
-        return format("%d\t%s", bytecodePosition, functionName);
+        return format("%d+%d\t%s", bytecodePosition, length, functionName);
     }
 }

--- a/source/grimoire/compiler/compiler.d
+++ b/source/grimoire/compiler/compiler.d
@@ -108,13 +108,14 @@ final class GrCompiler {
 			debug_info.bytecodePosition = lastOpcodeCount;
 			debug_info.functionName = "@global";
 			bytecode.debugInfo ~= debug_info;
-		}
-		if (globalScope) {
-			foreach (size_t i, instruction; globalScope.instructions)
-				opcodes[lastOpcodeCount + i] = makeOpcode(cast(uint) instruction.opcode,
-						instruction.value);
-			lastOpcodeCount += cast(uint) globalScope.instructions.length;
-			parser.removeFunction("@global");
+			if (globalScope) {
+				foreach (size_t i, instruction; globalScope.instructions)
+					opcodes[lastOpcodeCount + i] = makeOpcode(cast(uint) instruction.opcode,
+							instruction.value);
+				lastOpcodeCount += cast(uint) globalScope.instructions.length;
+				debug_info.length = cast(uint) globalScope.instructions.length;
+				parser.removeFunction("@global");
+			}
 		}
 
 		//Then write the main function (not callable).
@@ -125,16 +126,17 @@ final class GrCompiler {
 				debug_info.bytecodePosition = lastOpcodeCount;
 				debug_info.functionName = "main";
 				bytecode.debugInfo ~= debug_info;
-			}
 
-			mainFunc.position = lastOpcodeCount;
-			foreach (size_t i, instruction; mainFunc.instructions)
-				opcodes[lastOpcodeCount + i] = makeOpcode(cast(uint) instruction.opcode,
-						instruction.value);
-			foreach (call; mainFunc.functionCalls)
-				call.position += lastOpcodeCount;
-			lastOpcodeCount += cast(uint) mainFunc.instructions.length;
-			parser.removeFunction("main");
+				mainFunc.position = lastOpcodeCount;
+				foreach (size_t i, instruction; mainFunc.instructions)
+					opcodes[lastOpcodeCount + i] = makeOpcode(cast(uint) instruction.opcode,
+							instruction.value);
+				foreach (call; mainFunc.functionCalls)
+					call.position += lastOpcodeCount;
+				lastOpcodeCount += cast(uint) mainFunc.instructions.length;
+				debug_info.length = cast(uint) mainFunc.instructions.length;
+				parser.removeFunction("main");
+			}
 		}
 		else {
 			opcodes[lastOpcodeCount] = makeOpcode(cast(uint) GrOpcode.kill_, 0u);
@@ -149,15 +151,17 @@ final class GrCompiler {
 				debug_info.bytecodePosition = lastOpcodeCount;
 				debug_info.functionName = func.name;
 				bytecode.debugInfo ~= debug_info;
+
+				foreach (size_t i, instruction; func.instructions)
+					opcodes[lastOpcodeCount + i] = makeOpcode(cast(uint) instruction.opcode,
+							instruction.value);
+				foreach (call; func.functionCalls)
+					call.position += lastOpcodeCount;
+				func.position = lastOpcodeCount;
+				lastOpcodeCount += cast(uint) func.instructions.length;
+				debug_info.length = cast(uint) func.instructions.length;
+				events[func.mangledName] = func.position;
 			}
-			foreach (size_t i, instruction; func.instructions)
-				opcodes[lastOpcodeCount + i] = makeOpcode(cast(uint) instruction.opcode,
-						instruction.value);
-			foreach (call; func.functionCalls)
-				call.position += lastOpcodeCount;
-			func.position = lastOpcodeCount;
-			lastOpcodeCount += func.instructions.length;
-			events[func.mangledName] = func.position;
 		}
 		foreach (func; parser.anonymousFunctions) {
 			{
@@ -165,14 +169,16 @@ final class GrCompiler {
 				debug_info.bytecodePosition = lastOpcodeCount;
 				debug_info.functionName = func.name;
 				bytecode.debugInfo ~= debug_info;
+
+				foreach (size_t i, instruction; func.instructions)
+					opcodes[lastOpcodeCount + i] = makeOpcode(cast(uint) instruction.opcode,
+							instruction.value);
+				foreach (call; func.functionCalls)
+					call.position += lastOpcodeCount;
+				func.position = lastOpcodeCount;
+				lastOpcodeCount += func.instructions.length;
+				debug_info.length = cast(uint) func.instructions.length;
 			}
-			foreach (size_t i, instruction; func.instructions)
-				opcodes[lastOpcodeCount + i] = makeOpcode(cast(uint) instruction.opcode,
-						instruction.value);
-			foreach (call; func.functionCalls)
-				call.position += lastOpcodeCount;
-			func.position = lastOpcodeCount;
-			lastOpcodeCount += func.instructions.length;
 		}
 		foreach (func; parser.functions) {
 			{
@@ -180,14 +186,15 @@ final class GrCompiler {
 				debug_info.bytecodePosition = lastOpcodeCount;
 				debug_info.functionName = func.name;
 				bytecode.debugInfo ~= debug_info;
+				foreach (size_t i, instruction; func.instructions)
+					opcodes[lastOpcodeCount + i] = makeOpcode(cast(uint) instruction.opcode,
+							instruction.value);
+				foreach (call; func.functionCalls)
+					call.position += lastOpcodeCount;
+				func.position = lastOpcodeCount;
+				debug_info.length = cast(uint) func.instructions.length;
+				lastOpcodeCount += func.instructions.length;
 			}
-			foreach (size_t i, instruction; func.instructions)
-				opcodes[lastOpcodeCount + i] = makeOpcode(cast(uint) instruction.opcode,
-						instruction.value);
-			foreach (call; func.functionCalls)
-				call.position += lastOpcodeCount;
-			func.position = lastOpcodeCount;
-			lastOpcodeCount += func.instructions.length;
 		}
 		parser.solveFunctionCalls(opcodes);
 


### PR DESCRIPTION
Currently the printer has been added to the raise(GrContext,string) of the engine

It is probably necessary to add it to other relevant places but I am a potato like must of the time and I will leave the annoying work to you.